### PR TITLE
Enable conditional shortcuts

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -345,7 +345,7 @@ function obj.loadFirstValidTomlFile(paths)
   hs.hotkey.bind(leader_key_mods, leader_key, spoon.RecursiveBinder.recursiveBind(keys))
 end
 
-obj.registerFunctions = function(...)
+function obj.registerFunctions(...)
   for _, funcs in pairs({ ... }) do
     for k, v in pairs(funcs) do
       obj._userFunctions[k] = v

--- a/init.lua
+++ b/init.lua
@@ -261,7 +261,7 @@ function obj.loadFirstValidTomlFile(paths)
     for k, v in pairs(config) do
       if k == "label" then
         -- continue
-      elseif string.find(k, ":") then
+      elseif string.find(k, "_") then
         local key = k:sub(1, 1)
         local app = k:sub(3)
         if appSpecificActions == nil then appSpecificActions = {} end

--- a/init.lua
+++ b/init.lua
@@ -266,7 +266,7 @@ function obj.loadFirstValidTomlFile(paths)
         local app = k:sub(3)
         if appSpecificActions == nil then appSpecificActions = {} end
         if appSpecificActions[key] then
-          appSpecificActions[key][app] = v
+          appSpecificActions[key][app] = getActionAndLabel(v)
         else
           appSpecificActions[key] = { [app] = getActionAndLabel(v) }
         end


### PR DESCRIPTION
Inspired by [Hyperspoon](https://github.com/tighten/hyperspoon) by @andrewmile.

Hyperspoon lets users override keyboard shortcuts for specific applications. For example, if you want `cmd o` to always open the quick switcher, you could have this behavior:
```
when press cmd o:
in Slack:       cmd k
in VS Code:     cmd p
default:        passthrough
```

With this PR, you can accomplish a similar set up in Hammerflow. To map `leader o` to the various shortcuts:
```toml
o = "shortcut: cmd o"
"o:Code" = "shortcut: cmd p"
"o:Slack" = "shortcut: cmd k"
```

Unfortunately, TOML requires the key name to be quoted when it has a `:` in it. This is _fine_, but not as pretty as I'd like 😎 so I started playing with other options.

### Works without quotes
```
o-Code = ...
o_Code = ...
oCode = ...
```

### Requires quotes
```
"o:Code" = ...
"o|Code" = ...
o.Code  # this works syntactically, but is treated as a nested object instead of a single key
```

<hr/>

I think I'm leaning towards the underscore as the best option that doesn't require quotes. What do you think @andrewmile?