### PR TITLE
feat: add use_default_alert_style flag

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -273,6 +273,9 @@ function obj.loadFirstValidTomlFile(paths)
   if configFile.show_ui == false then
     spoon.RecursiveBinder.showBindHelper = false
   end
+  if configFile.use_default_alert_style == true then
+    spoon.RecursiveBinder.helperFormat = hs.alert.defaultStyle
+  end
 
   -- clear settings from table so we don't have to account
   -- for them in the recursive processing function
@@ -281,6 +284,7 @@ function obj.loadFirstValidTomlFile(paths)
   configFile.auto_reload = nil
   configFile.toast_on_reload = nil
   configFile.show_ui = nil
+  configFile.use_default_alert_style = nil
 
   local function parseKeyMap(config)
     local keyMap = {}

--- a/init.lua
+++ b/init.lua
@@ -273,9 +273,8 @@ function obj.loadFirstValidTomlFile(paths)
   if configFile.show_ui == false then
     spoon.RecursiveBinder.showBindHelper = false
   end
-  if configFile.use_default_alert_style == true then
-    spoon.RecursiveBinder.helperFormat = hs.alert.defaultStyle
-  end
+
+  spoon.RecursiveBinder.helperFormat = hs.alert.defaultStyle
 
   -- clear settings from table so we don't have to account
   -- for them in the recursive processing function
@@ -284,7 +283,6 @@ function obj.loadFirstValidTomlFile(paths)
   configFile.auto_reload = nil
   configFile.toast_on_reload = nil
   configFile.show_ui = nil
-  configFile.use_default_alert_style = nil
 
   local function parseKeyMap(config)
     local keyMap = {}

--- a/sample.toml
+++ b/sample.toml
@@ -15,7 +15,6 @@ leader_key_mods = ""      # optional, default "", not recommended - a dedicated 
 auto_reload = true        # optional, default true, reload when any file in this directory is saved
 toast_on_reload = true    # optional, default false, show a toast when the config is reloaded
 show_ui = true            # optional, default true, show the ui with your key maps
-use_default_alert_style = true # optional, default false, use hammerspoon default alert style
 
 
 # set a key to open an app

--- a/sample.toml
+++ b/sample.toml
@@ -15,6 +15,7 @@ leader_key_mods = ""      # optional, default "", not recommended - a dedicated 
 auto_reload = true        # optional, default true, reload when any file in this directory is saved
 toast_on_reload = true    # optional, default false, show a toast when the config is reloaded
 show_ui = true            # optional, default true, show the ui with your key maps
+use_default_alert_style = true # optional, default false, use hammerspoon default alert style
 
 
 # set a key to open an app


### PR DESCRIPTION
This PR adds a flag `use_default_alert_style` that allows Hammerflow to set Hammerspoon's default alert style in RecursiveBinder to maintain consistency.

I thought about using a function to set a different helper set only for Hammerflow but I think that users would want to use the same style for all Hammerspoon alerts.

My configuration:
```lua
function merge_tables(t1, t2)
    for k, v in pairs(t2) do
        if type(v) == "table" then
            if type(t1[k] or false) == "table" then
                merge_tables(t1[k] or {}, t2[k] or {})
            else
                t1[k] = v
            end
        else
            t1[k] = v
        end
    end
    return t1
end

local customStyle = {
    strokeWidth = 4,
    strokeColor = {white = 0.9, alpha = 0.9},
    fillColor = {white = 0.00, alpha = 1.0},
    textColor = {white = 0.9},
    textFont = "JetBrainsMono Nerd Font",
    textSize = 20,
    padding = 20,
    radius = 24,
    fadeInDuration = 0,
    fadeOutDuration = 0
}

hs.alert.defaultStyle = merge_tables(hs.alert.defaultStyle, customStyle)
```

Screenshot:
<img width="1800" alt="image" src="https://github.com/user-attachments/assets/64be5bb5-4fc4-44cf-a6d8-9a3996dd1889" />


I had a weird edge case where the toml parser would try to parse the boolean value as string but it might have been my fault (I'm using home-manager and I might have built my configuration at an inconsistent state).