### PR TITLE
Alfred URL Support

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -93,6 +93,9 @@ local raycast = function(link)
   -- pasting from emoji picker and window management
   return function() os.execute(string.format("open -g %s", link)) end
 end
+local things = function(link)
+  return function() os.execute(string.format("open %s", link)) end
+end
 local text = function(s)
   return function() hs.eventtap.keyStrokes(s) end
 end
@@ -178,6 +181,8 @@ local function getActionAndLabel(s)
     end, s
   elseif startswith(s, "raycast://") then
     return raycast(s), s
+  elseif startswith(s, "things:///") then
+    return things(s), s
   elseif startswith(s, "hs:") then
     return hs_run(postfix(s)), s
   elseif startswith(s, "cmd:") then

--- a/init.lua
+++ b/init.lua
@@ -88,6 +88,9 @@ end
 local open = function(link)
   return function() os.execute(string.format("open \"%s\"", link)) end
 end
+local alfred = function(link)
+  return function() os.execute(string.format("open %s", link)) end
+end
 local raycast = function(link)
   -- raycast needs -g to keep current app as "active" for
   -- pasting from emoji picker and window management
@@ -179,6 +182,8 @@ local function getActionAndLabel(s)
       hs.reload()
       hs.console.clearConsole()
     end, s
+  elseif startswith(s, "alfred://") then
+    return things(s), s
   elseif startswith(s, "raycast://") then
     return raycast(s), s
   elseif startswith(s, "things:///") then


### PR DESCRIPTION
Adding support for the Alfred `alfred://` external trigger URL scheme.

[Alfred External Trigger Docs](https://www.alfredapp.com/help/workflows/triggers/external/)