### PR TITLE
UI Customization & Dependency Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,39 @@ end
 4. Explore sample.toml to see what you can do and try out some of the default actions.
 5. Create your own toml config and personalize to your hearts content!
 
+## UI Formatting
+
+Customize the format of your Hammerflow UI using standard Hammerspoon formatting syntax and separate from.
+
+> [!IMPORTANT]
+> Any formatting must be registered before loading your toml configuration.
+
+```lua
+hs.loadSpoon("Hammerflow")
+-- optionally set ui format (must be done before loading toml config)
+-- 🧛 Dracula inspired theme
+spoon.Hammerflow.registerFormat({
+	atScreenEdge = 2,
+	fillColor = { alpha = .875, hex = "282b36" },
+	padding = 18,
+	radius = 12,
+	strokeColor = { alpha = .875, hex = "f1fa8b" },
+	textColor = { alpha = 1, hex = "bd93f9" },
+	textStyle = {
+		paragraphStyle = { lineSpacing = 6 },
+		shadow = { offset = { h = -1, w = 1 }, blurRadius = 10, color = { alpha = .50, white = 0 } }
+	},
+	strokeWidth = 6,
+	textFont = "JetBrainsMono NFM Bold",
+	textSize = 18,
+})
+spoon.Hammerflow.loadFirstValidTomlFile({
+	"home.toml",
+	"work.toml",
+	"Spoons/Hammerflow.spoon/sample.toml",
+})
+```
+
 ## Full Documentation
 All available options are demonstrated in [sample.toml](./sample.toml). I will create proper documentation soon.
 

--- a/Spoons/RecursiveBinder.spoon/docs.json
+++ b/Spoons/RecursiveBinder.spoon/docs.json
@@ -10,10 +10,20 @@
       {
         "def": "RecursiveBinder.recursiveBind(keymap)",
         "desc": "Bind sequential keys by a nested keymap.",
-        "doc": "Bind sequential keys by a nested keymap.\n\nParameters:\n * keymap - A table that specifies the mapping.\n\nReturns:\n * A function to start. Bind it to a initial key binding.\n\nNote:\nSpec of keymap:\nEvery key is of format {{modifers}, key, (optional) description}\nThe first two element is what you usually pass into a hs.hotkey.bind() function.\n\nEach value of key can be in two form:\n1. A function. Then pressing the key invokes the function\n2. A table. Then pressing the key bring to another layer of keybindings.\n   And the table have the same format of top table: keys to keys, value to table or function",
+        "doc": "Bind sequential keys by a nested keymap.\n\nParameters:\n * keymap - A table that specifies the mapping.\n\nReturns:\n * A function to start. Bind it to a initial key binding.\n\nNotes:\n * Spec of keymap:\n  * Every key is of format {{modifers}, key, (optional) description}\n  * The first two element is what you usually pass into a hs.hotkey.bind() function.\n  * Each value of key can be in two form:\n     1. A function. Then pressing the key invokes the function\n     2. A table. Then pressing the key bring to another layer of keybindings.\n     And the table have the same format of top table: keys to keys, value to table or function",
+        "examples": [],
         "file": "Source/RecursiveBinder.spoon//init.lua",
-        "lineno": "225",
+        "lineno": "228",
         "name": "recursiveBind",
+        "notes": [
+          " * Spec of keymap:",
+          "  * Every key is of format {{modifers}, key, (optional) description}",
+          "  * The first two element is what you usually pass into a hs.hotkey.bind() function.",
+          "  * Each value of key can be in two form:",
+          "     1. A function. Then pressing the key invokes the function",
+          "     2. A table. Then pressing the key bring to another layer of keybindings.",
+          "     And the table have the same format of top table: keys to keys, value to table or function"
+        ],
         "parameters": [
           " * keymap - A table that specifies the mapping."
         ],
@@ -21,16 +31,18 @@
           " * A function to start. Bind it to a initial key binding."
         ],
         "signature": "RecursiveBinder.recursiveBind(keymap)",
-        "stripped_doc": "Note:\nSpec of keymap:\nEvery key is of format {{modifers}, key, (optional) description}\nThe first two element is what you usually pass into a hs.hotkey.bind() function.\nEach value of key can be in two form:\n1. A function. Then pressing the key invokes the function\n2. A table. Then pressing the key bring to another layer of keybindings.\n   And the table have the same format of top table: keys to keys, value to table or function",
+        "stripped_doc": "",
         "type": "Method"
       },
       {
         "def": "RecursiveBinder.singleKey(key, name)",
         "desc": "this function simply return a table with empty modifiers also it translates capital letters to normal letter with shift modifer",
         "doc": "this function simply return a table with empty modifiers also it translates capital letters to normal letter with shift modifer\n\nParameters:\n * key - a letter\n * name - the description to pass to the keys binding function\n\nReturns:\n * a table of modifiers and keys and names, ready to be used in keymap\n   to pass to RecursiveBinder.recursiveBind()",
+        "examples": [],
         "file": "Source/RecursiveBinder.spoon//init.lua",
-        "lineno": "133",
+        "lineno": "137",
         "name": "singleKey",
+        "notes": [],
         "parameters": [
           " * key - a letter",
           " * name - the description to pass to the keys binding function"
@@ -81,23 +93,37 @@
       {
         "def": "RecursiveBinder.helperFormat",
         "desc": "format of helper, the helper is just a hs.alert",
-        "doc": "format of helper, the helper is just a hs.alert\ndefault to {atScreenEdge=2,\n            strokeColor={ white = 0, alpha = 2 },\n            textFont='SF Mono'\n            textSize=20}",
+        "doc": "format of helper, the helper is just a hs.alert\n\nNotes:\n * default to {atScreenEdge=2,\n            strokeColor={ white = 0, alpha = 2 },\n            textFont='SF Mono'\n            textSize=20}",
         "file": "Source/RecursiveBinder.spoon//init.lua",
         "lineno": "35",
         "name": "helperFormat",
+        "notes": [
+          " * default to {atScreenEdge=2,",
+          "            strokeColor={ white = 0, alpha = 2 },",
+          "            textFont='SF Mono'",
+          "            textSize=20}"
+        ],
         "signature": "RecursiveBinder.helperFormat",
-        "stripped_doc": "default to {atScreenEdge=2,\n            strokeColor={ white = 0, alpha = 2 },\n            textFont='SF Mono'\n            textSize=20}",
+        "stripped_doc": "",
         "type": "Variable"
       },
       {
         "def": "RecursiveBinder.helperModifierMapping()",
         "desc": "The mapping used to display modifiers on helper.",
-        "doc": "The mapping used to display modifiers on helper.\nDefault to {\n command = '⌘',\n control = '⌃',\n option = '⌥',\n shift = '⇧',\n}",
+        "doc": "The mapping used to display modifiers on helper.\n\nNotes:\n * Default to {\n command = '⌘',\n control = '⌃',\n option = '⌥',\n shift = '⇧',\n}",
         "file": "Source/RecursiveBinder.spoon//init.lua",
-        "lineno": "52",
+        "lineno": "54",
         "name": "helperModifierMapping",
+        "notes": [
+          " * Default to {",
+          " command = '⌘',",
+          " control = '⌃',",
+          " option = '⌥',",
+          " shift = '⇧',",
+          "}"
+        ],
         "signature": "RecursiveBinder.helperModifierMapping()",
-        "stripped_doc": "Default to {\n command = '⌘',\n control = '⌃',\n option = '⌥',\n shift = '⇧',\n}",
+        "stripped_doc": "",
         "type": "Variable"
       },
       {
@@ -105,7 +131,7 @@
         "desc": "whether to show helper, can be true of false",
         "doc": "whether to show helper, can be true of false",
         "file": "Source/RecursiveBinder.spoon//init.lua",
-        "lineno": "47",
+        "lineno": "49",
         "name": "showBindHelper",
         "signature": "RecursiveBinder.showBindHelper()",
         "stripped_doc": "",
@@ -151,32 +177,56 @@
       {
         "def": "RecursiveBinder.helperFormat",
         "desc": "format of helper, the helper is just a hs.alert",
-        "doc": "format of helper, the helper is just a hs.alert\ndefault to {atScreenEdge=2,\n            strokeColor={ white = 0, alpha = 2 },\n            textFont='SF Mono'\n            textSize=20}",
+        "doc": "format of helper, the helper is just a hs.alert\n\nNotes:\n * default to {atScreenEdge=2,\n            strokeColor={ white = 0, alpha = 2 },\n            textFont='SF Mono'\n            textSize=20}",
         "file": "Source/RecursiveBinder.spoon//init.lua",
         "lineno": "35",
         "name": "helperFormat",
+        "notes": [
+          " * default to {atScreenEdge=2,",
+          "            strokeColor={ white = 0, alpha = 2 },",
+          "            textFont='SF Mono'",
+          "            textSize=20}"
+        ],
         "signature": "RecursiveBinder.helperFormat",
-        "stripped_doc": "default to {atScreenEdge=2,\n            strokeColor={ white = 0, alpha = 2 },\n            textFont='SF Mono'\n            textSize=20}",
+        "stripped_doc": "",
         "type": "Variable"
       },
       {
         "def": "RecursiveBinder.helperModifierMapping()",
         "desc": "The mapping used to display modifiers on helper.",
-        "doc": "The mapping used to display modifiers on helper.\nDefault to {\n command = '⌘',\n control = '⌃',\n option = '⌥',\n shift = '⇧',\n}",
+        "doc": "The mapping used to display modifiers on helper.\n\nNotes:\n * Default to {\n command = '⌘',\n control = '⌃',\n option = '⌥',\n shift = '⇧',\n}",
         "file": "Source/RecursiveBinder.spoon//init.lua",
-        "lineno": "52",
+        "lineno": "54",
         "name": "helperModifierMapping",
+        "notes": [
+          " * Default to {",
+          " command = '⌘',",
+          " control = '⌃',",
+          " option = '⌥',",
+          " shift = '⇧',",
+          "}"
+        ],
         "signature": "RecursiveBinder.helperModifierMapping()",
-        "stripped_doc": "Default to {\n command = '⌘',\n control = '⌃',\n option = '⌥',\n shift = '⇧',\n}",
+        "stripped_doc": "",
         "type": "Variable"
       },
       {
         "def": "RecursiveBinder.recursiveBind(keymap)",
         "desc": "Bind sequential keys by a nested keymap.",
-        "doc": "Bind sequential keys by a nested keymap.\n\nParameters:\n * keymap - A table that specifies the mapping.\n\nReturns:\n * A function to start. Bind it to a initial key binding.\n\nNote:\nSpec of keymap:\nEvery key is of format {{modifers}, key, (optional) description}\nThe first two element is what you usually pass into a hs.hotkey.bind() function.\n\nEach value of key can be in two form:\n1. A function. Then pressing the key invokes the function\n2. A table. Then pressing the key bring to another layer of keybindings.\n   And the table have the same format of top table: keys to keys, value to table or function",
+        "doc": "Bind sequential keys by a nested keymap.\n\nParameters:\n * keymap - A table that specifies the mapping.\n\nReturns:\n * A function to start. Bind it to a initial key binding.\n\nNotes:\n * Spec of keymap:\n  * Every key is of format {{modifers}, key, (optional) description}\n  * The first two element is what you usually pass into a hs.hotkey.bind() function.\n  * Each value of key can be in two form:\n     1. A function. Then pressing the key invokes the function\n     2. A table. Then pressing the key bring to another layer of keybindings.\n     And the table have the same format of top table: keys to keys, value to table or function",
+        "examples": [],
         "file": "Source/RecursiveBinder.spoon//init.lua",
-        "lineno": "225",
+        "lineno": "228",
         "name": "recursiveBind",
+        "notes": [
+          " * Spec of keymap:",
+          "  * Every key is of format {{modifers}, key, (optional) description}",
+          "  * The first two element is what you usually pass into a hs.hotkey.bind() function.",
+          "  * Each value of key can be in two form:",
+          "     1. A function. Then pressing the key invokes the function",
+          "     2. A table. Then pressing the key bring to another layer of keybindings.",
+          "     And the table have the same format of top table: keys to keys, value to table or function"
+        ],
         "parameters": [
           " * keymap - A table that specifies the mapping."
         ],
@@ -184,7 +234,7 @@
           " * A function to start. Bind it to a initial key binding."
         ],
         "signature": "RecursiveBinder.recursiveBind(keymap)",
-        "stripped_doc": "Note:\nSpec of keymap:\nEvery key is of format {{modifers}, key, (optional) description}\nThe first two element is what you usually pass into a hs.hotkey.bind() function.\nEach value of key can be in two form:\n1. A function. Then pressing the key invokes the function\n2. A table. Then pressing the key bring to another layer of keybindings.\n   And the table have the same format of top table: keys to keys, value to table or function",
+        "stripped_doc": "",
         "type": "Method"
       },
       {
@@ -192,7 +242,7 @@
         "desc": "whether to show helper, can be true of false",
         "doc": "whether to show helper, can be true of false",
         "file": "Source/RecursiveBinder.spoon//init.lua",
-        "lineno": "47",
+        "lineno": "49",
         "name": "showBindHelper",
         "signature": "RecursiveBinder.showBindHelper()",
         "stripped_doc": "",
@@ -202,9 +252,11 @@
         "def": "RecursiveBinder.singleKey(key, name)",
         "desc": "this function simply return a table with empty modifiers also it translates capital letters to normal letter with shift modifer",
         "doc": "this function simply return a table with empty modifiers also it translates capital letters to normal letter with shift modifer\n\nParameters:\n * key - a letter\n * name - the description to pass to the keys binding function\n\nReturns:\n * a table of modifiers and keys and names, ready to be used in keymap\n   to pass to RecursiveBinder.recursiveBind()",
+        "examples": [],
         "file": "Source/RecursiveBinder.spoon//init.lua",
-        "lineno": "133",
+        "lineno": "137",
         "name": "singleKey",
+        "notes": [],
         "parameters": [
           " * key - a letter",
           " * name - the description to pass to the keys binding function"

--- a/Spoons/RecursiveBinder.spoon/init.lua
+++ b/Spoons/RecursiveBinder.spoon/init.lua
@@ -5,7 +5,7 @@
 ---
 --- [Click to download](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/RecursiveBinder.spoon.zip)
 
-local obj={}
+local obj = {}
 obj.__index = obj
 
 
@@ -20,7 +20,7 @@ obj.license = "MIT - https://opensource.org/licenses/MIT"
 --- RecursiveBinder.escapeKey
 --- Variable
 --- key to abort, default to {keyNone, 'escape'}
-obj.escapeKey = {keyNone, 'escape'}
+obj.escapeKey = { keyNone, 'escape' }
 
 --- RecursiveBinder.helperEntryEachLine
 --- Variable
@@ -35,14 +35,18 @@ obj.helperEntryLengthInChar = 20
 --- RecursiveBinder.helperFormat
 --- Variable
 --- format of helper, the helper is just a hs.alert
---- default to {atScreenEdge=2,
+---
+--- Notes:
+---  * default to {atScreenEdge=2,
 ---             strokeColor={ white = 0, alpha = 2 },
 ---             textFont='SF Mono'
 ---             textSize=20}
-obj.helperFormat = {atScreenEdge=2,
-                    strokeColor={ white = 0, alpha = 2 },
-                    textFont='Courier',
-                    textSize=20}
+obj.helperFormat = {
+   atScreenEdge = 2,
+   strokeColor = { white = 0, alpha = 2 },
+   textFont = 'Courier',
+   textSize = 20
+}
 
 --- RecursiveBinder.showBindHelper()
 --- Variable
@@ -52,7 +56,9 @@ obj.showBindHelper = true
 --- RecursiveBinder.helperModifierMapping()
 --- Variable
 --- The mapping used to display modifiers on helper.
---- Default to {
+---
+--- Notes:
+---  * Default to {
 ---  command = '⌘',
 ---  control = '⌃',
 ---  option = '⌥',
@@ -68,59 +74,59 @@ obj.helperModifierMapping = {
 -- used by next model to close previous helper
 local previousHelperID = nil
 
--- this function is used by helper to display 
+-- this function is used by helper to display
 -- appropriate 'shift + key' bindings
 -- it turns a lower key to the corresponding
 -- upper key on keyboard
 local function keyboardUpper(key)
    local upperTable = {
-    a='A', 
-    b='B', 
-    c='C', 
-    d='D', 
-    e='E', 
-    f='F', 
-    g='G', 
-    h='H', 
-    i='I', 
-    j='J', 
-    k='K', 
-    l='L', 
-    m='M', 
-    n='N', 
-    o='O', 
-    p='P', 
-    q='Q', 
-    r='R', 
-    s='S', 
-    t='T', 
-    u='U', 
-    v='V', 
-    w='W', 
-    x='X', 
-    y='Y', 
-    z='Z', 
-    ['`']='~',
-    ['1']='!',
-    ['2']='@',
-    ['3']='#',
-    ['4']='$',
-    ['5']='%',
-    ['6']='^',
-    ['7']='&',
-    ['8']='*',
-    ['9']='(',
-    ['0']=')',
-    ['-']='_',
-    ['=']='+',
-    ['[']='}',
-    [']']='}',
-    ['\\']='|',
-    [';']=':',
-    ['\'']='"',
-    [',']='<',
-    ['.']='>',
-    ['/']='?'
+      a = 'A',
+      b = 'B',
+      c = 'C',
+      d = 'D',
+      e = 'E',
+      f = 'F',
+      g = 'G',
+      h = 'H',
+      i = 'I',
+      j = 'J',
+      k = 'K',
+      l = 'L',
+      m = 'M',
+      n = 'N',
+      o = 'O',
+      p = 'P',
+      q = 'Q',
+      r = 'R',
+      s = 'S',
+      t = 'T',
+      u = 'U',
+      v = 'V',
+      w = 'W',
+      x = 'X',
+      y = 'Y',
+      z = 'Z',
+      ['`'] = '~',
+      ['1'] = '!',
+      ['2'] = '@',
+      ['3'] = '#',
+      ['4'] = '$',
+      ['5'] = '%',
+      ['6'] = '^',
+      ['7'] = '&',
+      ['8'] = '*',
+      ['9'] = '(',
+      ['0'] = ')',
+      ['-'] = '_',
+      ['='] = '+',
+      ['['] = '}',
+      [']'] = '}',
+      ['\\'] = '|',
+      [';'] = ':',
+      ['\''] = '"',
+      [','] = '<',
+      ['.'] = '>',
+      ['/'] = '?'
    }
    uppperKey = upperTable[key]
    if uppperKey then
@@ -144,17 +150,16 @@ end
 function obj.singleKey(key, name)
    local mod = {}
    if key == keyboardUpper(key) and string.len(key) == 1 then
-      mod = {'shift'}
+      mod = { 'shift' }
       key = string.lower(key)
    end
 
    if name then
-      return {mod, key, name}
+      return { mod, key, name }
    else
-      return {mod, key, 'no name'}
+      return { mod, key, 'no name' }
    end
 end
-
 
 -- generate a string representation of a key spec
 -- {{'shift', 'command'}, 'a} -> 'shift+command+a'
@@ -177,14 +182,14 @@ local function createKeyName(key)
          for count = 1, #modifierTable do
             local modifier = modifierTable[count]
             if count == 1 then
-               keyName = obj.helperModifierMapping[modifier]..' + '
-            else 
-               keyName = keyName..obj.helperModifierMapping[modifier]..' + '
+               keyName = obj.helperModifierMapping[modifier] .. ' + '
+            else
+               keyName = keyName .. obj.helperModifierMapping[modifier] .. ' + '
             end
          end
       end
       -- finally append key, e.g. 'f', after modifers
-      return keyName..keyString
+      return keyName .. keyString
    end
 end
 
@@ -196,10 +201,10 @@ local function compareLetters(a, b)
    local asciiA = string.byte(a)
    local asciiB = string.byte(b)
    if asciiA >= 65 and asciiA <= 90 then
-       asciiA = asciiA + 32.5
+      asciiA = asciiA + 32.5
    end
    if asciiB >= 65 and asciiB <= 90 then
-       asciiB = asciiB + 32.5
+      asciiB = asciiB + 32.5
    end
    return asciiA < asciiB
 end
@@ -208,38 +213,38 @@ end
 local function showHelper(keyFuncNameTable)
    -- keyFuncNameTable is a table that key is key name and value is description
    local helper = ''
-   local separator = '' -- first loop doesn't need to add a separator, because it is in the very front. 
+   local separator = '' -- first loop doesn't need to add a separator, because it is in the very front.
    local lastLine = ''
    local count = 0
 
    local sortedKeyFuncNameTable = {}
    for keyName, funcName in pairs(keyFuncNameTable) do
-       table.insert(sortedKeyFuncNameTable, {keyName = keyName, funcName = funcName})
+      table.insert(sortedKeyFuncNameTable, { keyName = keyName, funcName = funcName })
    end
    table.sort(sortedKeyFuncNameTable, function(a, b) return compareLetters(a.keyName, b.keyName) end)
+   print(hs.inspect(sortedKeyFuncNameTable))
 
    for _, value in ipairs(sortedKeyFuncNameTable) do
       local keyName = value.keyName
       local funcName = value.funcName
-      count = count + 1
-      local newEntry = keyName..' → '..funcName
+      local newEntry = keyName .. ' → ' .. funcName
       -- make sure each entry is of the same length
       if string.len(newEntry) > obj.helperEntryLengthInChar then
-         newEntry = string.sub(newEntry, 1, obj.helperEntryLengthInChar - 2)..'..'
+         newEntry = string.sub(newEntry, 1, obj.helperEntryLengthInChar - 2) .. '..'
       elseif string.len(newEntry) < obj.helperEntryLengthInChar then
-         newEntry = newEntry..string.rep(' ', obj.helperEntryLengthInChar - string.len(newEntry))
+         newEntry = newEntry .. string.rep(' ', obj.helperEntryLengthInChar - string.len(newEntry))
       end
       -- create new line for every helperEntryEachLine entries
-      if count % (obj.helperEntryEachLine + 1) == 0 then
-         separator = '\n '
-      elseif count == 1 then
-         separator = ' '
+      if count == 0 then
+         separator = ''
+      elseif count % obj.helperEntryEachLine == 0 then
+         separator = '\n'
       else
          separator = '  '
       end
-      helper = helper..separator..newEntry
+      helper = helper .. separator .. newEntry
+      count = count + 1
    end
-   helper = string.match(helper, '[^\n].+$')
    previousHelperID = hs.alert.show(helper, obj.helperFormat, true)
 end
 
@@ -257,15 +262,14 @@ end
 --- Returns:
 ---  * A function to start. Bind it to a initial key binding.
 ---
---- Note:
---- Spec of keymap:
---- Every key is of format {{modifers}, key, (optional) description}
---- The first two element is what you usually pass into a hs.hotkey.bind() function.
---- 
---- Each value of key can be in two form:
---- 1. A function. Then pressing the key invokes the function
---- 2. A table. Then pressing the key bring to another layer of keybindings.
----    And the table have the same format of top table: keys to keys, value to table or function
+--- Notes:
+---  * Spec of keymap:
+---   * Every key is of format {{modifers}, key, (optional) description}
+---   * The first two element is what you usually pass into a hs.hotkey.bind() function.
+---   * Each value of key can be in two form:
+---      1. A function. Then pressing the key invokes the function
+---      2. A table. Then pressing the key bring to another layer of keybindings.
+---      And the table have the same format of top table: keys to keys, value to table or function
 
 -- the actual binding function
 function obj.recursiveBind(keymap, modals)
@@ -279,17 +283,25 @@ function obj.recursiveBind(keymap, modals)
    local keyFuncNameTable = {}
    for key, map in pairs(keymap) do
       local func = obj.recursiveBind(map, modals)
-      -- key[1] is modifiers, i.e. {'shift'}, key[2] is key, i.e. 'f' 
-      modal:bind(key[1], key[2], function() modal:exit() killHelper() func() end)
-      modal:bind(obj.escapeKey[1], obj.escapeKey[2], function() modal:exit() killHelper() end)
+      -- key[1] is modifiers, i.e. {'shift'}, key[2] is key, i.e. 'f'
+      modal:bind(key[1], key[2], function()
+         modal:exit()
+         killHelper()
+         func()
+      end)
+      modal:bind(obj.escapeKey[1], obj.escapeKey[2], function()
+         modal:exit()
+         killHelper()
+      end)
       if #key >= 3 then
          keyFuncNameTable[createKeyName(key)] = key[3]
       end
    end
    return function()
-      -- exit all modals, accounts for pressing the leader key while in a modal
-      for _, m in ipairs(modals) do
-         m:exit()
+      -- exit all modals, accounts for pressing the trigger key while
+      -- a modal is already open
+      for _, modal in pairs(modals) do
+         modal:exit()
       end
       modal:enter()
       killHelper()
@@ -298,7 +310,6 @@ function obj.recursiveBind(keymap, modals)
       end
    end
 end
-
 
 -- function testrecursiveModal(keymap)
 --    print(keymap)

--- a/init.lua
+++ b/init.lua
@@ -93,6 +93,9 @@ local raycast = function(link)
   -- pasting from emoji picker and window management
   return function() os.execute(string.format("open -g %s", link)) end
 end
+local things = function(link)
+  return function() os.execute(string.format("open %s", link)) end
+end
 local text = function(s)
   return function() hs.eventtap.keyStrokes(s) end
 end
@@ -178,6 +181,8 @@ local function getActionAndLabel(s)
     end, s
   elseif startswith(s, "raycast://") then
     return raycast(s), s
+  elseif startswith(s, "things:///") then
+    return things(s), s
   elseif startswith(s, "hs:") then
     return hs_run(postfix(s)), s
   elseif startswith(s, "cmd:") then

--- a/init.lua
+++ b/init.lua
@@ -183,7 +183,7 @@ local function getActionAndLabel(s)
       hs.console.clearConsole()
     end, s
   elseif startswith(s, "alfred://") then
-    return things(s), s
+    return alfred(s), s
   elseif startswith(s, "raycast://") then
     return raycast(s), s
   elseif startswith(s, "things:///") then

--- a/init.lua
+++ b/init.lua
@@ -14,6 +14,7 @@ obj.license = "MIT - https://opensource.org/licenses/MIT"
 obj.auto_reload = false
 obj._userFunctions = {}
 obj._apps = {}
+obj._ui_format = nil
 
 -- lets us package RecursiveBinder with Hammerflow to include
 -- sorting and a bug fix that hasn't been merged upstream yet
@@ -283,8 +284,11 @@ function obj.loadFirstValidTomlFile(paths)
   if configFile.show_ui == false then
     spoon.RecursiveBinder.showBindHelper = false
   end
+  if configFile.key_maps_per_line ~= nil then
+    spoon.RecursiveBinder.helperEntryEachLine = configFile.key_maps_per_line
+  end
 
-  spoon.RecursiveBinder.helperFormat = hs.alert.defaultStyle
+  spoon.RecursiveBinder.helperFormat = obj._ui_format or hs.alert.defaultStyle
 
   -- clear settings from table so we don't have to account
   -- for them in the recursive processing function
@@ -293,6 +297,7 @@ function obj.loadFirstValidTomlFile(paths)
   configFile.auto_reload = nil
   configFile.toast_on_reload = nil
   configFile.show_ui = nil
+  configFile.key_maps_per_line = nil
 
   local function parseKeyMap(config)
     local keyMap = {}
@@ -379,6 +384,19 @@ function obj.registerFunctions(...)
       obj._userFunctions[k] = v
     end
   end
+end
+
+--- Register UI formatting using standard Hammerspoon syntax (see documentation links below).
+---
+--- NOTE: this must be called before Hammerflow.loadFirstValidTomlFile().
+---
+--- Alert Default Styling Docs: https://www.hammerspoon.org/docs/hs.alert.html#defaultStyle
+--- Text Styling Docs: https://www.hammerspoon.org/docs/hs.styledtext.html
+--- Color Styling Docs: https://www.hammerspoon.org/docs/hs.drawing.color.html
+---
+---@param opts table UI formatting options
+function obj.registerFormat(opts)
+  obj._ui_format = opts or {}
 end
 
 return obj

--- a/init.lua
+++ b/init.lua
@@ -88,6 +88,9 @@ end
 local open = function(link)
   return function() os.execute(string.format("open \"%s\"", link)) end
 end
+local alfred = function(link)
+  return function() os.execute(string.format("open %s", link)) end
+end
 local raycast = function(link)
   -- raycast needs -g to keep current app as "active" for
   -- pasting from emoji picker and window management
@@ -179,6 +182,8 @@ local function getActionAndLabel(s)
       hs.reload()
       hs.console.clearConsole()
     end, s
+  elseif startswith(s, "alfred://") then
+    return things(s), s
   elseif startswith(s, "raycast://") then
     return raycast(s), s
   elseif startswith(s, "things:///") then

--- a/sample.toml
+++ b/sample.toml
@@ -15,6 +15,7 @@ leader_key_mods = ""      # optional, default "", not recommended - a dedicated 
 auto_reload = true        # optional, default true, reload when any file in this directory is saved
 toast_on_reload = true    # optional, default false, show a toast when the config is reloaded
 show_ui = true            # optional, default true, show the ui with your key maps
+key_maps_per_line = 3     # optional, default 5, number of key maps per line in the ui
 
 
 # set a key to open an app


### PR DESCRIPTION
Adds the ability to custom the Hammerflow UI using a new Hammerflow.registerFormat() method. This method accepts a table of standard Hammerspoon formatting options (e.g. alert styling, text styling, color styling).

This commit also adds one new setting, `key_maps_per_line`. This allows users to limit the amount of keymaps displayed per line of the ui. I personally find the keymaps easier to read at a max of 1 or 2 per line (default is 5).

Example Screenshot
![sample_ui Small](https://github.com/user-attachments/assets/ba453f29-52f0-4262-acd5-10a95c38f7c1)

Finally, the RecursiveBinder.spoon dependency was updated to match the latest upstream release. This was done because of a recent bug fix that corrected how key map entries per line (`RecursiveBinder.helperEntryEachLine`) were calculated.

Updated README.md and sample.toml to reflect to changes.

NOTE: None of these changes require anything different from current users.