### PR TITLE
feat(actions): add menu: action to trigger app menu items from keymaps

### DIFF
--- a/sample.toml
+++ b/sample.toml
@@ -60,6 +60,8 @@ t = "text:sam@saml.dev"       # types "sam@saml.dev"
 z = "cmd:code ~/.zshrc"       # run any terminal command
 x = "code: ~/.zshrc"          # open a file or directory in VS Code
 s = "shortcut:cmd shift 4"    # trigger a keyboard shortcut
+w = "menu:File>New Window"    # select menu items (frontmost app)
+n = "menu:Safari|File>New Tab" # select menu items (specific app)
 r = "reload"                  # reserved for reloading your hammerspoon config (helpful when auto_reload is false)
 i = "input:https://google.com/search?q={input}" # capture input and insert it into any other action
 


### PR DESCRIPTION
First off, thank you for Hammerflow — it’s been super helpful. This PR proposes a `menu:` action that allows selecting standard application menu bar items directly from TOML, without writing Lua. I believe this strikes a nice balance between power and simplicity, but I completely understand if it feels too niche or adds unnecessary complexity

- New action: `menu:` to select menu items by path
  - Frontmost app: `menu:File>New Window`
  - Specific app by name: `menu:Safari|File>New Tab`
  - Deep submenu in frontmost app: `input:menu:File>Open Recent>{input}`

- Small helpers:
  - `menuAction(appName, menuPath, label)` to encapsulate selection/alerts
  - `trim` to normalize parsed strings

Behavior and limitations
- Uses `hs.application:selectMenuItem(menuPath, true)`
- Works for standard menu bar items that are visible/enabled at the moment
- Not intended for context (right‑click) menus or menu bar extras

Why I think it’s useful
- Triggering app menu items (Preferences…, New/Close Window, View toggles, etc.) is a common automation need
- Keeps config simple and consistent with other action types

I'm open to feedback regarding the naming of the action, as well as things like whether there should be an optional "focus app then select" variant, if you'd prefer that behavior. 

If this feels too specific for Hammerflow, I’m happy to keep it as a forked extension. Either way, thanks for considering it!